### PR TITLE
make compatible with sqlalchemy

### DIFF
--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+from sqlalchemy import types
+from sqlalchemy.util import generic_repr
+from typeid import TypeID, from_uuid
+
+
+class TypeIDType(types.TypeDecorator):
+    """
+    A SQLAlchemy TypeDecorator that allows storing TypeIDs in the database.
+    The prefix will not be persisted, instead the database-native UUID field will be used.
+    At retrieval time a TypeID will be constructed based on the configured prefix and the
+    UUID value from the database.
+
+    Usage:
+        # will result in TypeIDs such as "user_01h45ytscbebyvny4gc8cr8ma2"
+        id = mapped_column(
+            TypeIDType("user"),
+            primary_key=True,
+            default=lambda: TypeID("user")
+        )
+    """
+    impl = types.Uuid
+
+    cache_ok = True
+
+    prefix: Optional[str]
+
+    def __init__(self, prefix: Optional[str], *args, **kwargs):
+        self.prefix = prefix
+        super().__init__(*args, **kwargs)
+
+    def __repr__(self) -> str:
+        # Customize __repr__ to ensure that auto-generated code e.g. from alembic includes
+        # the right __init__ params (otherwise by default prefix will be omitted because
+        # uuid.__init__ does not have such an argument).
+        return generic_repr(
+            self,
+            to_inspect=TypeID(self.prefix),
+        )
+
+    def process_bind_param(self, value: TypeID, dialect):
+        if self.prefix is None:
+            assert value.prefix is None
+        else:
+            assert value.prefix == self.prefix
+
+        return value.uuid
+
+    def process_result_value(self, value, dialect):
+        return from_uuid(value, self.prefix)

--- a/tests/test_typeid.py
+++ b/tests/test_typeid.py
@@ -81,3 +81,15 @@ def test_construct_type_from_uuid_with_prefix() -> None:
     assert isinstance(typeid, TypeID)
     assert typeid.prefix == "prefix"
     assert isinstance(typeid.suffix, str)
+
+
+def test_hash_type_id() -> None:
+    prefix = "plov"
+    suffix = "00041061050r3gg28a1c60t3gf"
+
+    typeid_1 = TypeID(prefix=prefix, suffix=suffix)
+    typeid_2 = TypeID(prefix=prefix, suffix=suffix)
+    typeid_3 = TypeID(suffix=suffix)
+
+    assert hash(typeid_1) == hash(typeid_2)
+    assert hash(typeid_3) != hash(typeid_1)

--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -38,6 +38,9 @@ class TypeID:
             return False
         return value.prefix == self.prefix and value.suffix == self.suffix
 
+    def __hash__(self) -> int:
+        return hash((self.prefix, self.suffix))
+
 
 def from_string(string: str) -> TypeID:
     prefix, suffix = get_prefix_and_suffix(string=string)

--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -26,6 +26,10 @@ class TypeID:
     def prefix(self) -> str:
         return self._prefix
 
+    @property
+    def uuid(self) -> UUID:
+        return _convert_b32_to_uuid(self.suffix)
+
     def __str__(self) -> str:
         value = ""
         if self.prefix:
@@ -69,3 +73,7 @@ def get_prefix_and_suffix(string: str) -> tuple:
 
 def _convert_uuid_to_b32(uuid_instance: UUID) -> str:
     return base32.encode(list(uuid_instance.bytes))
+
+
+def _convert_b32_to_uuid(b32: str) -> UUID:
+    return UUID(bytes=bytes(base32.decode(b32)))


### PR DESCRIPTION
This PR was motivated by an issue I faced while I was trying to use TypeIDs as primary keys in a SQLAlchemy-based project, because SQLAlchemy was unable to index rows by their id (`TypeError: unhashable type: 'TypeID'`).

This PR does a few things:
1. it makes TypeIDs hashable[^1], so they can be used by SQLAlchemy as dictionary keys
2. it adds a `TypeID.uuid` property for easy extraction of the UUID for storage in SQLAlchemy
3. it adds `examples/sqlalchemy.py` with a simple example on how to use a TypeID as a SQLAlchemy column type

## Implementation details
This PR makes TypeID hashable[^1] by implementing a `__hash__` function that wraps prefix and suffix. Hashing the prefix will simply hash the string (or None), and hashing the suffix will simply defer to the UUID hash implementation[^2]. This implementation should have no interaction with the TypeID spec, because this type of hashing is only relevant within Python specifically to interoperate with other Python types. To my knowledge there is no common cross-language definition of the hashing algorithm.

[^1]: https://docs.python.org/3.11/glossary.html#term-hashable
[^2]: https://github.com/python/cpython/blob/afa7b0d743d9b7172d58d1e4c28da8324b9be2eb/Lib/uuid.py#L268-L269