### PR TITLE
add classmethod constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This particular implementation provides an pip package that can be used by any P
 - Create TypeID from string:
 
     ```python
-    from typeid import from_string
+    from typeid import TypeID
 
-    typeid = from_string("user_01h45ytscbebyvny4gc8cr8ma2")
+    typeid = TypeID.from_string("user_01h45ytscbebyvny4gc8cr8ma2")
 
     print(str(typeid))  # "user_01h45ytscbebyvny4gc8cr8ma2"
     ```
@@ -69,13 +69,13 @@ This particular implementation provides an pip package that can be used by any P
 - Create TypeID from uuid7:
 
     ```python
-    from typeid import from_uuid
+    from typeid import TypeID
     from uuid6 import uuid7
 
     uuid = uuid7()  # UUID('01890bf0-846f-7762-8605-5a3abb40e0e5')
     prefix = "user"
 
-    typeid = from_uuid(prefix=prefix, suffix=uuid)
+    typeid = TypeID.from_uuid(prefix=prefix, suffix=uuid)
 
     print(str(typeid))  # "user_01h45z113fexh8c1at7axm1r75"
     ```

--- a/tests/test_typeid.py
+++ b/tests/test_typeid.py
@@ -38,6 +38,16 @@ def test_compare_typeid() -> None:
 def test_construct_type_from_string() -> None:
     string = "00041061050r3gg28a1c60t3gf"
 
+    typeid = TypeID.from_string(string)
+
+    assert isinstance(typeid, TypeID)
+    assert typeid.prefix == ""
+    assert isinstance(typeid.suffix, str)
+
+
+def test_construct_type_from_string_standalone() -> None:
+    string = "00041061050r3gg28a1c60t3gf"
+
     typeid = from_string(string)
 
     assert isinstance(typeid, TypeID)
@@ -46,6 +56,16 @@ def test_construct_type_from_string() -> None:
 
 
 def test_construct_type_from_string_with_prefix() -> None:
+    string = "prefix_00041061050r3gg28a1c60t3gf"
+
+    typeid = TypeID.from_string(string)
+
+    assert isinstance(typeid, TypeID)
+    assert typeid.prefix == "prefix"
+    assert isinstance(typeid.suffix, str)
+
+
+def test_construct_type_from_string_with_prefix_standalone() -> None:
     string = "prefix_00041061050r3gg28a1c60t3gf"
 
     typeid = from_string(string)

--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -18,6 +18,16 @@ class TypeID:
         self._prefix = prefix or ""
         self._suffix = suffix
 
+    @classmethod
+    def from_string(cls, string: str):
+        prefix, suffix = get_prefix_and_suffix(string=string)
+        return cls(suffix=suffix, prefix=prefix)
+
+    @classmethod
+    def from_uuid(cls, suffix: UUID, prefix: Optional[str] = None):
+        suffix_str = _convert_uuid_to_b32(suffix)
+        return TypeID(suffix=suffix_str, prefix=prefix)
+
     @property
     def suffix(self) -> str:
         return self._suffix
@@ -40,13 +50,13 @@ class TypeID:
 
 
 def from_string(string: str) -> TypeID:
-    prefix, suffix = get_prefix_and_suffix(string=string)
-    return TypeID(suffix=suffix, prefix=prefix)
+    """Consider TypeID.from_string instead."""
+    return TypeID.from_string(string=string)
 
 
 def from_uuid(suffix: UUID, prefix: Optional[str] = None) -> TypeID:
-    suffix_str = _convert_uuid_to_b32(suffix)
-    return TypeID(suffix=suffix_str, prefix=prefix)
+    """Consider TypeID.from_uuid instead."""
+    return TypeID.from_uuid(suffix=suffix, prefix=prefix)
 
 
 def get_prefix_and_suffix(string: str) -> tuple:


### PR DESCRIPTION
This PR moves the implementation of `from_string` and `from_uuid` to classmethods of the same name.

That means instead of
```python
from typeid import from_string

the_id = from_string(...)
```
...you can now write:
```python
from typeid import TypeID

the_id = TypeID.from_string(...)
```

I've kept the old methods around for now, but they defer to the new classmethods as the source implementation. If you're onboard with this change you could also consider dropping them, but they probably don't hurt and it would be a breaking change.

## Motivation

- It's a common pattern in the Python world ("Also, see `classmethod()` for a variant that is useful for creating alternate class constructors."[^1 ])
- It will often reduce the number of imports from the `typeid` package, because it's likely you'll already import `TypeID` anyway for e.g. function param or return typing (`def find_by_id(id: TypeID)`).
- Especially `from_string` is a fairly ambiguous name, and importing it in a large file might often need an alias
- When dealing in a big project it's easier to remember a generic import (`TypeID`) rather than the constructors for each library ("Was it `from_uuid` or `get_by_uuid`...?")
- It follows the [TypeScript TypeID library](https://github.com/jetpack-io/typeid-js#usage) which uses `TypeID.fromString` and `TypeID.fromUUID`

[^1]: https://docs.python.org/3/library/functions.html#staticmethod