### PR TITLE
Updated prefix validation to match type-id regex

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -15,6 +15,22 @@ def test_validate_correct_prefix() -> None:
         pytest.fail(str(exc))
 
 
+def test_validate_correct_prefix_with_underscores() -> None:
+    prefix = "plov_good"
+
+    try:
+        validate_prefix(prefix)
+    except PrefixValidationException as exc:
+        pytest.fail(str(exc))
+
+
+def test_validate_invalid_prefix_with_trailing_underscore() -> None:
+    prefix = "plov_bad_"
+
+    with pytest.raises(PrefixValidationException):
+        validate_prefix(prefix)
+
+
 def test_validate_uppercase_prefix() -> None:
     prefix = "Plov"
 

--- a/typeid/validation.py
+++ b/typeid/validation.py
@@ -1,10 +1,13 @@
+import re
+
 from typeid import base32
-from typeid.constants import PREFIX_MAX_LEN, SUFFIX_LEN
+from typeid.constants import SUFFIX_LEN
 from typeid.errors import PrefixValidationException, SuffixValidationException
 
 
 def validate_prefix(prefix: str) -> None:
-    if not prefix.islower() or not prefix.isascii() or len(prefix) > PREFIX_MAX_LEN or not prefix.isalpha():
+    # See https://github.com/jetify-com/typeid/tree/main/spec
+    if not re.match("^([a-z]([a-z_]{0,61}[a-z])?)?$", prefix):
         raise PrefixValidationException(f"Invalid prefix: {prefix}.")
 
 


### PR DESCRIPTION
As part of TypeID v0.3.0 release a proposal was accepted to allow underscores within the prefix. This PR includes changes to introduce the TypeID regex specification.