### PR TITLE
fix: Improve type prefix and suffix extraction

### DIFF
--- a/tests/test_typeid.py
+++ b/tests/test_typeid.py
@@ -84,6 +84,16 @@ def test_construct_type_from_string_with_prefix_standalone() -> None:
     assert isinstance(typeid.suffix, str)
 
 
+def test_construct_type_from_string_with_multi_underscore_prefix() -> None:
+    string = "double_prefix_00041061050r3gg28a1c60t3gf"
+
+    typeid = TypeID.from_string(string)
+
+    assert isinstance(typeid, TypeID)
+    assert typeid.prefix == "double_prefix"
+    assert isinstance(typeid.suffix, str)
+
+
 def test_construct_type_from_invalid_string() -> None:
     string = "invalid_string_to_typeid"
 

--- a/tests/test_typeid.py
+++ b/tests/test_typeid.py
@@ -2,7 +2,7 @@ import pytest
 import uuid6
 
 from typeid import TypeID
-from typeid.errors import InvalidTypeIDStringException
+from typeid.errors import SuffixValidationException
 
 
 def test_default_suffix() -> None:
@@ -87,7 +87,7 @@ def test_construct_type_from_string_with_prefix_standalone() -> None:
 def test_construct_type_from_invalid_string() -> None:
     string = "invalid_string_to_typeid"
 
-    with pytest.raises(InvalidTypeIDStringException):
+    with pytest.raises(SuffixValidationException):
         TypeID.from_string(string)
 
 

--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -80,15 +80,12 @@ def from_uuid(suffix: uuid6.UUID, prefix: Optional[str] = None) -> TypeID:
 
 
 def get_prefix_and_suffix(string: str) -> tuple:
-    parts = string.split("_")
-    prefix = None
+    parts = string.rsplit("_", 1)
     if len(parts) == 1:
+        prefix = None
         suffix = parts[0]
-    elif len(parts) == 2 and parts[0] != "":
-        suffix = parts[1]
-        prefix = parts[0]
     else:
-        raise InvalidTypeIDStringException(f"Invalid TypeID: {string}")
+        prefix, suffix = parts
 
     return prefix, suffix
 

--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -84,6 +84,8 @@ def get_prefix_and_suffix(string: str) -> tuple:
     if len(parts) == 1:
         prefix = None
         suffix = parts[0]
+    elif len(parts) == 2 and parts[0] == "":
+        raise InvalidTypeIDStringException(f"Invalid TypeID: {string}")
     else:
         prefix, suffix = parts
 


### PR DESCRIPTION
Refactored the logic in `get_prefix_and_suffix` function to improve type prefix and suffix extraction. Now using `rsplit` method to accurately extract the prefix and suffix from the input string. 

Closes #12