### PR TITLE
chore: enable catching all TypeID exceptions

### DIFF
--- a/typeid/errors.py
+++ b/typeid/errors.py
@@ -2,13 +2,13 @@ class TypeIDException(Exception):
     ...
 
 
-class PrefixValidationException(Exception):
+class PrefixValidationException(TypeIDException):
     ...
 
 
-class SuffixValidationException(Exception):
+class SuffixValidationException(TypeIDException):
     ...
 
 
-class InvalidTypeIDStringException(Exception):
+class InvalidTypeIDStringException(TypeIDException):
     ...


### PR DESCRIPTION
Subclasses Exception classes from a single base class to enable users to catch a single Exception type for all TypeID errors.