### PR TITLE
feat: make TypeID repr output executable by adding .from_string()

### DIFF
--- a/typeid/typeid.py
+++ b/typeid/typeid.py
@@ -48,7 +48,7 @@ class TypeID:
         return value
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, str(self))
+        return "%s.from_string(%r)" % (self.__class__.__name__, str(self))
 
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, TypeID):


### PR DESCRIPTION
Fixes #18

Previously, TypeID.__repr__() returned TypeID('prefix_suffix') which was not valid Python code since the constructor doesn't accept strings directly. This made it impossible to copy-paste TypeID representations from error messages or interactive sessions.

Now __repr__() returns TypeID.from_string('prefix_suffix'), making the output directly executable and copy-pasteable into Python interpreters.

All existing tests pass with this change.