### PR TITLE
ci: add linux/arm64 (aarch64) wheel builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,22 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             python-version: "3.14"
+          # Linux ARM64 (cross-compiled on ubuntu-latest via maturin-action)
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python-version: "3.10"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python-version: "3.11"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python-version: "3.12"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python-version: "3.13"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python-version: "3.14"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds `manylinux_2_28_aarch64` wheels to the publish workflow for Python 3.10–3.14.

The `maturin-action` handles cross-compilation natively for `aarch64-unknown-linux-gnu` on the existing `ubuntu-latest` runners — no new runner types or dependencies needed.

Tested locally on macOS Apple Silicon by building inside `quay.io/pypa/manylinux_2_28_aarch64` and confirming a valid `manylinux_2_28_aarch64` wheel is produced.